### PR TITLE
Remove unintended character in `ads/header.tex`

### DIFF
--- a/ads/header.tex
+++ b/ads/header.tex
@@ -60,7 +60,7 @@
 \usepackage[onehalfspacing]{setspace}
 \usepackage{makeidx}
 \usepackage[autostyle=true,german=quotes]{csquotes}
-2\usepackage{enumitem}	% mehr Optionen bei Aufzählungen
+\usepackage{enumitem}	% mehr Optionen bei Aufzählungen
 \usepackage{graphicx}
 \usepackage{pdfpages}   % zum Einbinden von PDFs
 \usepackage{xcolor} 	% für HTML-Notation


### PR DESCRIPTION
# Problem 
In `ads/header.tex`, there is - probably unintended - the character `2` at the beginning of line 63. Hence, an extra page at the beginning of the document with the content `2` is added in the compiled pdf.

# Solution
Remove the character.